### PR TITLE
Update to guard for dig already implemented

### DIFF
--- a/lib/dig_rb/array.rb
+++ b/lib/dig_rb/array.rb
@@ -1,4 +1,4 @@
-unless Array.respond_to?(:dig)
+unless Array.instance_methods.include?(:dig)
   Array.class_eval do
     def dig(key, *args)
       value = self.at(key)

--- a/lib/dig_rb/hash.rb
+++ b/lib/dig_rb/hash.rb
@@ -1,4 +1,4 @@
-unless Hash.respond_to?(:dig)
+unless Hash.instance_methods.include?(:dig)
   Hash.class_eval do
     # Retrieves the value object corresponding to the each key objects repeatedly.
     #

--- a/lib/dig_rb/ostruct.rb
+++ b/lib/dig_rb/ostruct.rb
@@ -1,5 +1,5 @@
 require 'ostruct'
-unless OpenStruct.respond_to?(:dig)
+unless OpenStruct.instance_methods.include?(:dig)
   OpenStruct.class_eval do
     #
     # Retrieves the value object corresponding to the each +name+

--- a/lib/dig_rb/struct.rb
+++ b/lib/dig_rb/struct.rb
@@ -1,4 +1,4 @@
-unless Struct.respond_to?(:dig)
+unless Struct.instance_methods.include?(:dig)
   Struct.class_eval do
 
     # Extracts the nested value specified by the sequence of <i>idx</i>


### PR DESCRIPTION
The classes themselves are not going to respond to `#dig`, but we can check their instance methods.
